### PR TITLE
fix(scanner): show an out-of-stock product instead of an empty screen

### DIFF
--- a/barcode-scanner-frontend/src/components/UserDashboard/UserDashboard.js
+++ b/barcode-scanner-frontend/src/components/UserDashboard/UserDashboard.js
@@ -20,7 +20,7 @@ import {recordScan} from '../../utils/scanLog';
 import useDailySnapshot from '../../hooks/useDailySnapshot';
 import DailySnapshot from './DailySnapshot';
 import groupItemsBySku from './groupItemsBySku';
-import {isStockBlocked, stockStatusMessageKey} from './stockStatus';
+import {hasProductResult, isStockBlocked, stockStatusMessageKey} from './stockStatus';
 import inheritFromGroup from './inheritFromGroup';
 import displayCustomerName from '../../utils/orderDisplay';
 import OfflineBanner, {useOfflineStatus} from './OfflineBanner';
@@ -817,7 +817,9 @@ const UserDashboard = () => {
 
     const {offline: activeOrderOffline, pending: activeOrderPending} = useOfflineStatus(activeOrder?.id);
 
-    const hasResults = balances.length > 0 || (stockUnavailable && !!productInfo.sku);
+    // A resolved product is a result even with no stock anywhere — see
+    // hasProductResult in stockStatus.js.
+    const hasResults = hasProductResult(productInfo, balances);
     const showEmptyProductState = !hasResults && !scannerOpen;
     const showOrderPanel = orderMode && activeOrder;
 
@@ -906,6 +908,15 @@ const UserDashboard = () => {
                                 type="warning"
                                 showIcon
                                 message={t[stockStatusMessageKey(stockStatus)]}
+                                style={{margin: '12px 0'}}
+                            />
+                        )}
+
+                        {!stockUnavailable && balances.length === 0 && (
+                            <Alert
+                                type="info"
+                                showIcon
+                                message={t.outOfStock}
                                 style={{margin: '12px 0'}}
                             />
                         )}

--- a/barcode-scanner-frontend/src/components/UserDashboard/stockStatus.js
+++ b/barcode-scanner-frontend/src/components/UserDashboard/stockStatus.js
@@ -23,3 +23,15 @@ export const isStockBlocked = (status) => Boolean(status);
 export const stockStatusMessageKey = (status) => (
     status === STOCK_STATUS_NO_LOOKUP_KEY ? 'stockLookupKeyMissing' : 'stockUnavailable'
 );
+
+/**
+ * Whether a search produced something worth showing.
+ *
+ * A resolved product counts even with no stock anywhere: its card, price and
+ * images must render rather than collapsing to the "nothing scanned yet" empty
+ * state. Balances alone also count, so a result never disappears just because
+ * the product payload was thinner than expected.
+ */
+export const hasProductResult = (productInfo, balances) => (
+    Boolean(productInfo?.sku) || (balances || []).length > 0
+);

--- a/barcode-scanner-frontend/src/components/UserDashboard/stockStatus.test.js
+++ b/barcode-scanner-frontend/src/components/UserDashboard/stockStatus.test.js
@@ -1,6 +1,7 @@
 import {
     STOCK_STATUS_NO_LOOKUP_KEY,
     STOCK_STATUS_UNAVAILABLE,
+    hasProductResult,
     isStockBlocked,
     stockStatusMessageKey,
 } from './stockStatus';
@@ -30,5 +31,36 @@ describe('stockStatusMessageKey', () => {
     it('falls back to the outage wording for unavailable and anything unknown', () => {
         expect(stockStatusMessageKey(STOCK_STATUS_UNAVAILABLE)).toBe('stockUnavailable');
         expect(stockStatusMessageKey('something_new')).toBe('stockUnavailable');
+    });
+});
+
+describe('hasProductResult', () => {
+    const resolved = {sku: '000000007126', sku_name: 'GASTRO'};
+    const cleared = {sku_name: '', article: '', price: '', images: []};
+
+    it('counts a resolved product with stock as a result', () => {
+        expect(hasProductResult(resolved, [{warehouse: 'W1', quantity: '3.000'}])).toBe(true);
+    });
+
+    it('counts a resolved product with NO stock anywhere as a result', () => {
+        // Regression: an out-of-stock product used to fail its 1C lookup and so
+        // arrived flagged "unavailable", which is what kept the card on screen.
+        // Now it legitimately returns an empty stock list with no status, and
+        // the card must still render instead of the blank empty state.
+        expect(hasProductResult(resolved, [])).toBe(true);
+    });
+
+    it('is not a result before anything has been searched', () => {
+        expect(hasProductResult(cleared, [])).toBe(false);
+    });
+
+    it('is not a result after a failed search clears the product', () => {
+        expect(hasProductResult(cleared, [])).toBe(false);
+        expect(hasProductResult({}, [])).toBe(false);
+    });
+
+    it('tolerates a missing balances list', () => {
+        expect(hasProductResult(resolved, undefined)).toBe(true);
+        expect(hasProductResult(cleared, undefined)).toBe(false);
     });
 });


### PR DESCRIPTION
Fixes the regression reported after #4 was merged: scanning a product shows nothing — no stock, no warehouses, no product card.

## Cause

`hasResults` gates the entire result block:

```js
const hasResults = balances.length > 0 || (stockUnavailable && !!productInfo.sku);
```

That only ever worked because an out-of-stock product used to *fail* its 1C lookup with a 421 and arrive flagged `stock_status: "unavailable"` — the bug fixed in #4 was propping the card up. With #4 merged, such a product correctly returns an empty stock list and no status, so both sides of the expression are false and the scanner falls through to the "nothing scanned yet" empty state. The product, its price and its images all disappear after a *successful* scan.

## Fix

`hasProductResult` replaces the inline expression — a resolved product is a result whether or not it has stock — and an empty balance list now renders the existing "out of stock" notice rather than leaving a blank gap under the card.

The predicate moves into `stockStatus.js` with tests. This is the second defect in this component traced to an untested boolean gating the render, so the logic now lives somewhere it can be pinned.

## Verification

109 frontend tests pass (5 new, covering the resolved-but-no-stock case that regressed). `UserDashboard.js` and `stockStatus.js` parse-checked through `babel-preset-react-app`, since no test imports the dashboard component itself.

Worth noting: the CI added in #4 runs backend tests only, so it would not have caught this. Adding a frontend job is the obvious follow-up — `App.test.js` currently fails on a pre-existing `Cannot find module 'react-router-dom'`, which needs sorting first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)