### PR TITLE
ci: add a frontend job and fix the Jest failure that blocked it

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,47 @@
+name: Frontend tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - djangoRewrite
+
+concurrency:
+  group: frontend-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Jest suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: barcode-scanner-frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Matches the engines field in barcode-scanner-frontend/package.json.
+      # The Node version is load-bearing here: --openssl-legacy-provider below
+      # exists because of how Node 22 and this pinned CRA webpack interact.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: barcode-scanner-frontend/package-lock.json
+
+      # `npm ci` installs exactly what package-lock.json pins and fails if the
+      # lockfile and package.json disagree, so CI cannot drift from developers.
+      - name: Install dependencies
+        run: npm ci
+
+      # CI=true makes react-scripts run once and treat warnings as errors it
+      # reports rather than sitting in watch mode. --openssl-legacy-provider is
+      # required for the CRA 5 webpack/Node combination this app is pinned to;
+      # dropping it breaks every script in package.json.
+      - name: Run tests
+        env:
+          CI: true
+        run: npx react-scripts --openssl-legacy-provider test --watchAll=false

--- a/barcode-scanner-frontend/package.json
+++ b/barcode-scanner-frontend/package.json
@@ -52,7 +52,9 @@
   },
   "jest": {
     "moduleNameMapper": {
-      "^@rc-component/([^/]+)/(?!lib/|es/|assets/)(.*)$": "@rc-component/$1/lib/$2"
+      "^@rc-component/([^/]+)/(?!lib/|es/|assets/)(.*)$": "@rc-component/$1/lib/$2",
+      "^react-router-dom$": "<rootDir>/node_modules/react-router-dom/dist/index.js",
+      "^react-router/dom$": "<rootDir>/node_modules/react-router/dist/development/dom-export.js"
     },
     "transformIgnorePatterns": [
       "[/\\\\]node_modules[/\\\\](?!axios[/\\\\]).+\\.(js|jsx|mjs|cjs|ts|tsx)$",

--- a/barcode-scanner-frontend/src/App.test.js
+++ b/barcode-scanner-frontend/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/barcode-scanner-frontend/src/components/PrivateRoute.test.js
+++ b/barcode-scanner-frontend/src/components/PrivateRoute.test.js
@@ -1,0 +1,81 @@
+import {render, screen} from '@testing-library/react';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import PrivateRoute from './PrivateRoute';
+import AuthContext from './Auth/AuthContext';
+
+const SECRET = 'protected page';
+const LOGIN = 'login page';
+const USER_HOME = 'user dashboard';
+const ADMIN_HOME = 'admin dashboard';
+
+const renderGuarded = (authData, allowedRoles) => render(
+    <AuthContext.Provider value={{authData}}>
+        <MemoryRouter initialEntries={['/secret']}>
+            <Routes>
+                <Route
+                    path="/secret"
+                    element={(
+                        <PrivateRoute allowedRoles={allowedRoles}>
+                            <div>{SECRET}</div>
+                        </PrivateRoute>
+                    )}
+                />
+                <Route path="/login" element={<div>{LOGIN}</div>}/>
+                <Route path="/dashboard" element={<div>{USER_HOME}</div>}/>
+                <Route path="/system-admin-dashboard" element={<div>{ADMIN_HOME}</div>}/>
+            </Routes>
+        </MemoryRouter>
+    </AuthContext.Provider>,
+);
+
+describe('PrivateRoute', () => {
+    afterEach(() => localStorage.clear());
+
+    it('sends an unauthenticated visitor to login', () => {
+        renderGuarded(null, ['company_user']);
+        expect(screen.getByText(LOGIN)).toBeInTheDocument();
+        expect(screen.queryByText(SECRET)).not.toBeInTheDocument();
+    });
+
+    it('treats a missing token as unauthenticated even with a role', () => {
+        renderGuarded({role: 'company_user'}, ['company_user']);
+        expect(screen.getByText(LOGIN)).toBeInTheDocument();
+    });
+
+    it('renders the page when the role is allowed', () => {
+        renderGuarded({token: 't', role: 'company_user'}, ['company_user']);
+        expect(screen.getByText(SECRET)).toBeInTheDocument();
+    });
+
+    it('sends a company_user away from an admin-only page', () => {
+        renderGuarded({token: 't', role: 'company_user'}, ['company_admin']);
+        expect(screen.getByText(USER_HOME)).toBeInTheDocument();
+        expect(screen.queryByText(SECRET)).not.toBeInTheDocument();
+    });
+
+    it('sends a company_admin away from a user-only page', () => {
+        renderGuarded({token: 't', role: 'company_admin'}, ['company_user']);
+        expect(screen.getByText(ADMIN_HOME)).toBeInTheDocument();
+    });
+
+    it('sends an internal_admin to the admin dashboard', () => {
+        renderGuarded({token: 't', role: 'internal_admin'}, ['company_user']);
+        expect(screen.getByText(ADMIN_HOME)).toBeInTheDocument();
+    });
+
+    it('sends an unrecognised role to login rather than guessing a home', () => {
+        renderGuarded({token: 't', role: 'something_else'}, ['company_user']);
+        expect(screen.getByText(LOGIN)).toBeInTheDocument();
+    });
+
+    it('falls back to the stored role when authData carries none', () => {
+        localStorage.setItem('role', 'company_user');
+        renderGuarded({token: 't'}, ['company_user']);
+        expect(screen.getByText(SECRET)).toBeInTheDocument();
+    });
+
+    it('allows any role when the route declares no restriction', () => {
+        renderGuarded({token: 't', role: 'company_user'}, undefined);
+        expect(screen.getByText(SECRET)).toBeInTheDocument();
+    });
+});

--- a/barcode-scanner-frontend/src/setupTests.js
+++ b/barcode-scanner-frontend/src/setupTests.js
@@ -3,3 +3,16 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// react-router 7 reaches for TextEncoder/TextDecoder at import time. The jsdom
+// bundled with CRA 5's Jest 27 does not expose either as a global, so any test
+// that pulls in a routed component dies on `TextEncoder is not defined`. Node
+// has had both in `util` since v11.
+import {TextDecoder, TextEncoder} from 'util';
+
+if (typeof global.TextEncoder === 'undefined') {
+    global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+    global.TextDecoder = TextDecoder;
+}


### PR DESCRIPTION
Follow-up to #5: the backend CI added in #4 would not have caught that regression, because it runs backend tests only. This adds the frontend job, which first meant fixing the Jest failure that was blocking it.

## Why `App.test.js` failed

It could never have passed. It is untouched Create React App scaffold — one commit, the original `added basic front-end` — asserting a "learn react" link this barcode app has never contained. But it failed long before that assertion, and the cause was worth understanding rather than deleting past.

`react-router-dom@7.13.1` declares `"main": "./dist/main.js"`, a file it does not ship (`dist/` contains only `index.js`, `index.mjs` and typings). The package relies entirely on its `exports` map. CRA 5 pins `jest-resolve@27`, which predates `exports` support (Jest 28), so Jest falls back to the missing `main` and reports `Cannot find module 'react-router-dom'`. Webpack 5 *does* honour `exports`, which is exactly why the app builds and runs fine while only Jest broke.

Two `moduleNameMapper` entries point Jest at the real files, sitting alongside the `@rc-component` workaround already in `package.json` for the same class of problem. `react-router`'s own `main` is valid, so only its `./dom` subpath needs one.

That exposed a second, unrelated cause: react-router 7 touches `TextEncoder` at import time, and the jsdom bundled with CRA 5's Jest exposes no such global. `setupTests.js` now polyfills it from node's `util`.

## Why the test is replaced rather than repaired

With resolution fixed, `App.test.js` turned out to pull in the whole component tree — `App` → `UserDashboard` → `ClientLookupModal` → `AddressMapPicker` → `react-leaflet`, which ships ESM only and would need its own transform exception plus DOM APIs jsdom lacks. Making a full-app render work is a deep rabbit hole in service of a test that asserts something false.

So it is deleted, and replaced with `PrivateRoute.test.js`: nine cases over the role-gating logic, which is security-relevant and had no coverage at all. It also exercises the router fix directly, since it imports `MemoryRouter`/`Routes`/`Route`. Mutation-checked — replacing the role check with `if (false)` fails four of the nine.

## The workflow

Pins Node 22 to match the `engines` field, since `--openssl-legacy-provider` exists because of that exact Node/CRA pairing, and uses `npm ci` so CI cannot drift from the lockfile.

## Verification

346 backend tests and 118 frontend tests (17 suites) pass locally, no failures in either.

One caveat I cannot resolve locally: this worktree lives under a `.claude/worktrees/` path, and the `\.` in that segment breaks Jest's default `<rootDir>` glob, so I verified with an explicit `--testMatch`. A normal CI checkout has no such path segment, so the default matcher the workflow uses should be fine — but its first real run is the proof, not my local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)